### PR TITLE
Agrega página Not Found (404).

### DIFF
--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import "../styles/NotFound.css";
+import { Link } from "react-router-dom";
+
+const NotFoundPage = () => {
+    return (
+        <div className="notfound-container">
+        <h1 className="notfound-code">404</h1>
+        <h2 className="notfound-title">Página no encontrada</h2>
+        <p className="notfound-text">
+            Lo sentimos, la página que buscas no existe o fue movida.
+        </p>
+        <Link to="/" className="notfound-btn">
+            Volver al inicio
+        </Link>
+        </div>
+    );
+};
+
+export default NotFoundPage;

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -2,6 +2,7 @@
 import Home from '../pages/HomePage';
 import AboutUs from '../pages/AboutUsPage';
 import Login from '../pages/LoginPage';
+import NotFoundPage from '../pages/NotFoundPage';
 
 const routes = [
   {
@@ -16,6 +17,10 @@ const routes = [
     path: '/login',
     element: <Login />
   },
+  {
+    path: '*',
+    element: <NotFoundPage/>
+  }
 
   // {
   //   path: '/help-center',

--- a/src/styles/NotFound.css
+++ b/src/styles/NotFound.css
@@ -1,0 +1,46 @@
+.notfound-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 70vh;
+  text-align: center;
+  background-color: #fafafa;
+  color: #222;
+  font-family: "Montserrat", sans-serif;
+}
+
+.notfound-code {
+  font-size: 96px;
+  font-weight: 700;
+  margin: 0;
+  color: #d9534f; /* Rojo sobrio alineado al banner */
+}
+
+.notfound-title {
+  font-size: 24px;
+  font-weight: 600;
+  margin: 10px 0;
+  color: #333;
+}
+
+.notfound-text {
+  font-size: 16px;
+  color: #666;
+  margin-bottom: 24px;
+  max-width: 400px;
+}
+
+.notfound-btn {
+  display: inline-block;
+  padding: 10px 20px;
+  background-color: #d9534f;
+  color: white;
+  text-decoration: none;
+  border-radius: 6px;
+  transition: background 0.3s ease;
+}
+
+.notfound-btn:hover {
+  background-color: #c9302c;
+}


### PR DESCRIPTION
- Se crea componente NotFoundPage.jsx en carpeta pages.
- Se añade NotFound.css en carpeta styles para estilos consistentes con el resto del proyecto.
- La página muestra mensaje de error 404, texto explicativo y botón para volver al inicio.
- Se actualizan rutas para incluir un catch all (*) que redirige a NotFoundPage.
- Diseño minimalista, colores y tipografía alineados con el resto del proyecto.